### PR TITLE
v4.11

### DIFF
--- a/LTS.py
+++ b/LTS.py
@@ -13,7 +13,7 @@
 """
 # TouchFish 协议文档
 
-本协议文档版本：v2.6.0
+本协议文档版本：v2.7.0
 
 本协议分为三个部分：`Gate`，`Chat`，`Misc`。
 
@@ -23,6 +23,8 @@
 
 # 协议更新日志
 
+- Protocol v2.7.0 (TouchFish v4.10.0)
+  - 添加对心跳数据的说明，没有实际改动
 - Protocol v2.6.0 (TouchFish v4.9.0)
   - 恢复 v2.3.0 的字段更改
 - Protocol v2.5.0 (TouchFish v4.8.0)
@@ -269,7 +271,7 @@
 
 客户端正常关闭时将事件写入日志。
 
-- `type`: `"MISC.MISC.CLIENT_STOP"`
+- `type`: `"MISC.CLIENT_STOP"`
 - `time`: 同上。
 
 ## 3.5 Server Stop
@@ -336,6 +338,10 @@
 - `key`: 同上。
 - `value`: 同上。
 - `operator`: 执行修改操作的用户 ID。
+
+# 4 Keepalive
+
+发送的消息中可能包含空行，这些空行起心跳数据的作用。
 """
 
 
@@ -362,7 +368,7 @@ import threading
 import time
 
 # 程序版本
-VERSION = "v4.9.0"
+VERSION = "v4.10.0"
 
 # 用于客户端解析协议 1.2
 RESULTS = \
@@ -445,7 +451,7 @@ general.max_connections     最大允许连接数，
 DEFAULT_SERVER_CONFIG = \
 {
 	"side": "Server",
-	"general": {"server_ip": "127.0.0.1", "server_port": 8080, "server_username": "root", "max_connections": 128},
+	"general": {"server_ip": "0.0.0.0", "server_port": 8080, "server_username": "root", "max_connections": 128},
 	"ban": {"ip": [], "words": []},
 	"gate": {"enter_hint": "", "enter_check": False},
 	"message": {"allow_private": True, "max_length": 16384},
@@ -695,6 +701,9 @@ online_count        在线人数（包括状态为 Root，Admin，
                     参见 HELP_HINT 第 3 段，下同）
 buffer              my_socket 读取时模拟的缓冲区
                     （发送的数据都是 NDJSON，因此遇到换行符则清空）
+bell_countdown      用于在收到广播时响铃 5 次以体现公告的重要性，
+                    第 1 次为默认响铃，后 4 次中每 1.5 秒响铃一次，
+                    对应 15 次 thread_output 的循环
 exit_flag           默认为 False，程序终止改为 True，通知所有线程终止
 log_queue           记录需要写入日志的信息，数据格式为 str(JSON)
 print_queue         用于输入模式下记录被阻塞的输出内容（每行一条），
@@ -744,6 +753,7 @@ server_version = VERSION
 history = []
 online_count = 1
 buffer = ""
+bell_countdown = 0
 exit_flag = False
 log_queue = queue.Queue()
 receive_queue = queue.Queue()
@@ -894,7 +904,10 @@ def announce(uid):
 
 # 其他消息的消息头（根据协议 2.2 进行解析）
 def print_message(message):
+	global bell_countdown
 	first_line = dye("[" + message["time"][11:19] + "]", "black")
+	if message["order"] > 0:
+		first_line += dye(" (#" + str(message["order"]) + ")", "black")
 	if message["from"] == my_uid:
 		first_line += dye(" [您发送的]", "blue")
 	if message["to"] == my_uid:
@@ -906,6 +919,14 @@ def print_message(message):
 		pass
 	if message["to"] == -2:
 		first_line += dye(" [广播]", "red")
+		# 增加 bell_countdown 的值以请求
+		# thread_output 完成额外的 4 次响铃，
+		# 由于 thread_output 先将 bell_countdown
+		# 减去 1 再判断是否响铃，因此第 2 次
+		# 响铃出现在 1.5 秒后 bell_countdown
+		# 为 60 的时刻，第 5 次响铃出现在 6 秒后
+		# bell_countdown 为 15 的时刻
+		bell_countdown += 75
 	if message["to"] >= 0:
 		first_line += dye(" [私聊]", "green")
 	first_line += " "
@@ -1119,15 +1140,25 @@ def do_doorman(arg, verbose=True, by=-1):
 	if not arg[0] in ["accept", "reject"]:
 		printc(verbose, "参数错误：第一个参数必须是 accept 和 reject 中的某一项。")
 		return
+
+	if side == "Server":
+		# 先发送心跳数据（连续 10 个换行符）检查客户端是否下线
+		try:
+			for _ in range(10):
+				users[arg[1]]["body"].send(bytes("\n", encoding="utf-8"))
+		except:
+			users[arg[1]]["body"].close() # 关闭相应 TCP socket
+			users[arg[1]]["status"] = "Offline"
+			online_count -= 1
+			log_queue.put(json.dumps({"type": "GATE.STATUS_CHANGE.LOG", "time": time_str(), "status": "Offline", "uid": arg[1], "operator": 0})) # 协议 1.6.3
+			for i in range(len(users)):
+				if users[i]["status"] in ["Online", "Admin", "Root"]:
+						send_queue.put(json.dumps({"to": i, "content": {"type": "GATE.STATUS_CHANGE.ANNOUNCE", "status": "Offline", "uid": arg[1], "operator": 0}})) # 协议 1.6.2
+			printc(verbose, "操作失败：该用户在操作前已经下线。")
+			return
 	
 	if arg[0] == "accept":
 		if side == "Server":
-			# 重要：最后再给该用户发送信息，防止出现
-			# 该用户已经断开连接而状态没有更新的情况
-			log_queue.put(json.dumps({"type": "GATE.STATUS_CHANGE.LOG", "time": time_str(), "status": "Online", "uid": arg[1], "operator": by})) # 协议 1.6.3
-			for i in range(len(users)):
-				if users[i]["status"] in ["Online", "Admin", "Root"]:
-					send_queue.put(json.dumps({"to": i, "content": {"type": "GATE.STATUS_CHANGE.ANNOUNCE", "status": "Online", "uid": arg[1], "operator": by}})) # 协议 1.6.2
 			# 根据协议 3.2 生成适合客户端的 users 字段
 			users[arg[1]]["status"] = "Online"
 			users_abstract = []
@@ -1359,14 +1390,14 @@ def do_ban(arg, verbose=True, by=-1):
 		
 		if arg[1] == "add":
 			if side == "Server":
-				ips = [item for item in ips if item not in config["ban"]["ip"]]
+				ips = [item for item in ips if not item in config["ban"]["ip"]]
 				config["ban"]["ip"] += ips
 				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.6.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
 						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.6.2
 			if side == "Client":
-				ips = [item for item in ips if item not in config["ban"]["ip"]]
+				ips = [item for item in ips if not item in config["ban"]["ip"]]
 				new_value = config["ban"]["ip"] + ips
 				upload({"type": "MISC.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.6.1
 			printc(verbose, "操作成功，共计封禁了 {} 个 IP 地址。".format(len(ips)))
@@ -1865,7 +1896,7 @@ thread_check        轮番检查各客户端是否下线，并给服务端保活
 
 # 所有线程均使用 while True 的无限循环，
 # 每轮开始前暂停 0.1 秒防止 CPU 占用过高，
-# 且均受程序终止信号 exit_flag 的调控。
+# 且均受程序终止信号 exit_flag 的调控
 
 def thread_gate():
 	global online_count
@@ -2056,9 +2087,10 @@ def thread_send():
 			message = json.loads(send_queue.get())
 			if not users[message["to"]]["status"] in ["Online", "Admin", "Root", "Pending"]:
 				continue
-			# 先发送心跳数据（单个换行符）检查客户端是否下线
+			# 先发送心跳数据（连续 10 个换行符）检查客户端是否下线
 			try:
-				users[message["to"]]["body"].send(bytes("\n", encoding="utf-8"))
+				for _ in range(10):
+					users[message["to"]]["body"].send(bytes("\n", encoding="utf-8"))
 			except:
 				users[message["to"]]["body"].close() # 关闭相应 TCP socket
 				users[message["to"]]["status"] = "Offline"
@@ -2129,7 +2161,9 @@ def thread_check():
 		for i in range(len(users)):
 			if users[i]["status"] in ["Online", "Admin", "Root"] and not users[i]["busy"]:
 				try:
-					users[i]["body"].send(bytes("\n", encoding="utf-8")) # 发送心跳数据（单个换行符）
+					# 发送心跳数据（连续 10 个换行符）
+					for _ in range(10):
+						users[i]["body"].send(bytes("\n", encoding="utf-8"))
 				except:
 					users[i]["body"].close() # 关闭相应 TCP socket
 					users[i]["status"] = "Offline"
@@ -2191,12 +2225,18 @@ def thread_input():
 		blocked = False
 
 def thread_output():
+	global bell_countdown
 	global exit_flag
 	while True:
 		time.sleep(0.1)
 		if exit_flag:
 			print("\033[0m", end="", flush=True)
 			return
+		
+		if bell_countdown:
+			bell_countdown -= 1
+		if bell_countdown and bell_countdown % 15 == 0:
+			ring()
 		
 		read()
 		message = get_message()
@@ -2231,6 +2271,7 @@ def main():
 	global history
 	global online_count
 	global buffer
+	global bell_countdown
 	global exit_flag
 	global log_queue
 	global receive_queue
@@ -2687,11 +2728,13 @@ def main():
 							prints("连接成功！", "green")
 							ring()
 							break
+					except SystemExit:
+						sys.exit(1)
 					except:
 						pass
 					clock_end = datetime.datetime.now().timestamp()
 					seconds_consumed += 1
-					time.sleep(1 - (clock_end - clock_start))
+					time.sleep(max(1 - (clock_end - clock_start), 0))
 			
 			side = "Client"
 			# 获取服务端通过协议 3.2 提供的完整上下文；
@@ -2713,6 +2756,7 @@ def main():
 			do_dashboard()
 			for i in first_data["chat_history"]:
 				print_message(i)
+				bell_countdown = 0 # 历史消息中的广播不需要额外响铃
 			if config["gate"]["enter_hint"]:
 				first_line = dye("[" + time_str()[11:19] + "]", "black")
 				first_line += dye(" [加入提示]", "red")

--- a/LTS.py
+++ b/LTS.py
@@ -13,7 +13,7 @@
 """
 # TouchFish 协议文档
 
-本协议文档版本：v2.7.0
+本协议文档版本：v2.8.0
 
 本协议分为三个部分：`Gate`，`Chat`，`Misc`。
 
@@ -23,6 +23,8 @@
 
 # 协议更新日志
 
+- Protocol v2.8.0 (TouchFish v4.11.0)
+  - 撤销 v2.3.0 的字段更改
 - Protocol v2.7.0 (TouchFish v4.10.0)
   - 添加对心跳数据的说明，没有实际改动
 - Protocol v2.6.0 (TouchFish v4.9.0)
@@ -69,11 +71,11 @@
 
 - `type`: `"GATE.RESPONSE"`
 - `result`: 字符串，可能取值包括：（下同）
-  - `"Accepted"`：立即允许加入；
-  - `"Pending review"`：需人工审核；
-  - `"IP is banned"`：当前 IP 被封禁；
-  - `"Room is full"`：服务端用户数已达上限；
-  - `"Duplicate usernames"`：用户名已被使用；
+  - `"Accepted"`：立即允许加入。
+  - `"Pending review"`：需人工审核。
+  - `"IP is banned"`：当前 IP 被封禁。
+  - `"Room is full"`：服务端用户数已达上限。
+  - `"Duplicate usernames"`：用户名已被使用。
   - `"Username consists of banned words"`：用户名包含违禁词。
 
 ## 1.3 Review Result
@@ -85,7 +87,7 @@
 - `type`: `"GATE.REVIEW_RESULT"`
 - `accepted`: 布尔值，`true` 表示通过，`false` 表示拒绝。
 - `operator`: 审核者信息：
-  - `username`: 操作者用户名；
+  - `username`: 操作者用户名。
   - `uid`: 操作者的用户 ID。（除特殊说明外，用户 ID 为非负整数，下同）
 
 ## 1.4 Incorrect Protocol
@@ -137,12 +139,12 @@
 
 - `type`: `"GATE.STATUS_CHANGE.REQUEST"`
 - `status`: 字符串，表示目标状态，可能取值包括：（下同）
-  - `"Rejected"`：连接被拒绝的用户；（本协议中表示管理员拒绝加入请求）
-  - `"Kicked"`：被踢出聊天室的用户；（本协议中表示管理员主动踢出用户）
-  - `"Offline"`：主动离开聊天室的用户；（本协议中不会出现）
-  - `"Pending"`：等待加入审核的用户；（本协议中不会出现）
-  - `"Online"`：在线用户；（本协议中表示管理员通过加入请求）
-  - `"Admin"`：在线管理员；（本协议中不会出现）
+  - `"Rejected"`：连接被拒绝的用户。（本协议中表示管理员拒绝加入请求）
+  - `"Kicked"`：被踢出聊天室的用户。（本协议中表示管理员主动踢出用户）
+  - `"Offline"`：主动离开聊天室的用户。（本协议中不会出现）
+  - `"Pending"`：等待加入审核的用户。（本协议中不会出现）
+  - `"Online"`：在线用户。（本协议中表示管理员通过加入请求）
+  - `"Admin"`：在线管理员。（本协议中不会出现）
   - `"Root"`：聊天室房主。（本协议中不会出现）
 - `uid`: 被操作用户的用户 ID。
 
@@ -181,11 +183,11 @@
 客户端发送消息或文件。
 
 - `type`: `"CHAT.SEND"`
-- `filename`: 文件名。若发送的是普通文本消息，则为空字符串 `""`；若发送文件，则为原始文件名。（下同）
+- `filename`: 若发送的是普通文本消息，则为空字符串 `""`；若发送文件，则为原始文件名。（下同）
 - `content`: 若为消息，则为原始文本内容；若为文件，则为文件内容的 Base64 编码字符串。（下同）
 - `to`: 目标接收者，可能取值包括：（下同）
-  - `-2`：广播给所有在线用户（相较于普通发送有特殊提示）；
-  - `-1`：发送给所有在线用户；
+  - `-2`：广播给所有在线用户（相较于普通发送有特殊提示）。
+  - `-1`：发送给所有在线用户。
   - 非负整数：私聊给拥有相应用户 ID 的用户。
 
 ## 2.2 Receive
@@ -197,7 +199,7 @@
 - `type`: `"CHAT.RECEIVE"`
 - `from`: 发送者的用户 ID。（下同）
 - `order`: 消息编号，可能取值包括：（下同）
-  - 正整数：普通文本消息；
+  - 正整数：普通文本消息。
   - 负整数：文件编号。
 - `filename`: 同上。
 - `content`: 同上。
@@ -219,17 +221,17 @@
 
 ---
 
-# 3 Misc
+# 3 Server
 
 这个部分是关于程序运行情况的协议内容。
 
 ## 3.1 Start
 
-`{ type: "MISC.START", time: time, stamp: number, version: string, config: JSON }`
+`{ type: "SERVER.START", time: time, stamp: number, version: string, config: JSON }`
 
 程序将启动时的启动参数写入日志。
 
-- `type`: `"MISC.START"`
+- `type`: `"SERVER.START"`
 - `time`: 同上。
 - `stamp`: 用于指定文件保存路径，取启动时的 UNIX 时间戳乘 `10 ** 6` 后向下取整。
 - `version`: 字符串，表示服务端程序版本。（下同）
@@ -237,103 +239,94 @@
 
 ## 3.2 Data
 
-`{ type: "MISC.DATA", server_version: string, uid: number, config: JSON, users: [JSON, ...], chat_history: [JSON, ...] }`
+`{ type: "SERVER.DATA", server_version: string, uid: number, config: JSON, users: [JSON, ...], chat_history: [JSON, ...] }`
 
 用于向新连接的客户端提供完整上下文。
 
-- `type`: `"MISC.DATA"`
+- `type`: `"SERVER.DATA"`
 - `server_version`: 同上。
 - `uid`: 表示服务端分配给该用户的用户 ID。
 - `config`: 同上。
 - `users`: 用户列表，每个元素为：
-  - `username`: 用户名；
+  - `username`: 用户名。
   - `status`: 同上。
 - `chat_history`: 历史聊天记录，每条记录包含：（不包含私聊记录和文件发送记录）
-  - `time`: 同上；
-  - `order`：同上；
-  - `from`: 同上；
-  - `content`: 同上；
+  - `time`: 同上。
+  - `order`：同上。
+  - `from`: 同上。
+  - `content`: 同上。
   - `to`: 同上。
 
 ## 3.3 Command
 
-`{ type: "MISC.COMMAND", time: time, command: string }`
+`{ type: "SERVER.COMMAND", time: time, command: string }`
 
 程序将用户输入的指令写入日志。
 
-- `type`: `"MISC.COMMAND"`
+- `type`: `"SERVER.COMMAND"`
 - `time`: 同上。
 - `command`: 输入的指令。
 
-## 3.4 Client Stop
+## 3.4 Stop
 
-`{ type: "MISC.CLIENT_STOP", time: time }`
+程序正常关闭时的协议。
 
-客户端正常关闭时将事件写入日志。
+### 3.4.1 Announce
 
-- `type`: `"MISC.CLIENT_STOP"`
-- `time`: 同上。
-
-## 3.5 Server Stop
-
-服务端正常关闭时的协议。
-
-### 3.5.1 Announce
-
-`{ type: "MISC.SERVER_STOP.ANNOUNCE" }`
+`{ type: "SERVER.STOP.ANNOUNCE" }`
 
 服务端正常关闭时，向全体客户端进行广播。
 
-- `type`: `"MISC.SERVER_STOP.ANNOUNCE"`
+- `type`: `"SERVER.STOP.ANNOUNCE"`
 
-### 3.5.2 Log
+### 3.4.2 Log
 
-`{ type: "MISC.SERVER_STOP.LOG", time: time }`
+`{ type: "SERVER.STOP.LOG", time: time }`
 
-服务端正常关闭时将事件写入日志。
+程序正常关闭时将事件写入日志。
 
-- `type`: `"MISC.SERVER_STOP.LOG"`
+- `type`: `"SERVER.STOP.LOG"`
 - `time`: 同上。
 
-## 3.6 Config
+## 3.5 Config
 
-### 3.6.1 Post
+### 3.5.1 Post
 
-`{ type: "MISC.CONFIG.POST", key: string, value: any }`
+`{ type: "SERVER.CONFIG.POST", key: string, value: any }`
 
 管理员向服务端发送配置修改请求。
 
-- `type`: `"MISC.CONFIG.POST"`
+- `type`: `"SERVER.CONFIG.POST"`
 - `key`: 配置项名称。（下同）
 - `value`: 配置值。（下同）
 
-### 3.6.2 Change
+### 3.5.2 Change
 
-`{ type: "MISC.CONFIG.CHANGE", key: string, value: any, operator: number }`
+`{ type: "SERVER.CONFIG.CHANGE", key: string, value: any, operator: number }`
 
 服务端向客户端广播配置修改事件。
 
-- `type`: `"MISC.CONFIG.CHANGE"`
+- `type`: `"SERVER.CONFIG.CHANGE"`
 - `key`: 同上。
 - `value`: 同上。
 - `operator`: 执行修改操作的用户 ID。
 
-### 3.6.3 Save
+### 3.5.3 Save
 
-`{ type: "MISC.CONFIG.SAVE", time: time }`
+`{ type: "SERVER.CONFIG.SAVE", time: time }`
 
 服务端将聊天室房主导出配置的事件写入日志。
 
-- `type`: `"MISC.CONFIG.SAVE"`
+- `type`: `"SERVER.CONFIG.SAVE"`
 - `time`: 同上。
 
-### 3.6.4 Log
+### 3.5.4 Log
 
-`{ type: "MISC.CONFIG.LOG", time: time, key: string, value: any, operator: number }`
+`{ type: "SERVER.CONFIG.LOG", time: time, key: string, value: any, operator: number }`
 
 服务端将配置修改事件写入日志。
 
-- `type`: `"MISC.CONFIG.LOG"`
+- `type`: `"SERVER.CONFIG.LOG"`
 - `time`: 同上。
 - `key`: 同上。
 - `value`: 同上。
@@ -368,7 +361,7 @@ import threading
 import time
 
 # 程序版本
-VERSION = "v4.10.0"
+VERSION = "v4.11.0"
 
 # 用于客户端解析协议 1.2
 RESULTS = \
@@ -1005,7 +998,7 @@ def process(message):
 			prints("\033[0m\033[1;36m再见！\033[0m")
 			exit_flag = True
 			return
-	if message["type"] == "MISC.CONFIG.CHANGE": # 服务端参数变更 (协议 3.6.2)
+	if message["type"] == "SERVER.CONFIG.CHANGE": # 服务端参数变更 (协议 3.5.2)
 		announce(message["operator"])
 		prints("配置项 {} 变更为：".format(message["key"]) + str(message["value"]), "cyan")
 		if side == "Client": # 同上
@@ -1016,7 +1009,7 @@ def process(message):
 				prints("该配置项相比修改前移除了：{}".format(str(deletions)), "cyan")
 		config[message["key"].split(".")[0]][message["key"].split(".")[1]] = message["value"]
 		return
-	if message["type"] == "MISC.SERVER_STOP.ANNOUNCE": # 服务端关闭 (协议 3.5.1)
+	if message["type"] == "SERVER.STOP.ANNOUNCE": # 服务端关闭 (协议 3.5.1)
 		if side == "Client": # 同上
 			announce(0)
 			prints("聊天室服务端已经关闭。", "cyan")
@@ -1145,7 +1138,7 @@ def do_doorman(arg, verbose=True, by=-1):
 		# 先发送心跳数据（连续 10 个换行符）检查客户端是否下线
 		try:
 			for _ in range(10):
-				users[arg[1]]["body"].send(bytes("\n", encoding="utf-8"))
+				users[arg[1]]["body"].send(bytes("\n", encoding="utf-8")) # 协议 4
 		except:
 			users[arg[1]]["body"].close() # 关闭相应 TCP socket
 			users[arg[1]]["status"] = "Offline"
@@ -1165,7 +1158,7 @@ def do_doorman(arg, verbose=True, by=-1):
 			for i in range(len(users)):
 				users_abstract.append({"username": users[i]["username"], "status": users[i]["status"]})
 			send_queue.put(json.dumps({"to": arg[1], "content": {"type": "GATE.REVIEW_RESULT", "accepted": True, "operator": {"username": users[by]["username"], "uid": by}}})) # 协议 1.3
-			send_queue.put(json.dumps({"to": arg[1], "content": {"type": "MISC.DATA", "server_version": VERSION, "uid": arg[1], "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
+			send_queue.put(json.dumps({"to": arg[1], "content": {"type": "SERVER.DATA", "server_version": VERSION, "uid": arg[1], "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
 		if side == "Client":
 			upload({"type": "GATE.STATUS_CHANGE.REQUEST", "status": "Online", "uid": arg[1]}) # 协议 1.6.1
 	
@@ -1346,12 +1339,12 @@ def do_config(arg, verbose=True, by=-1):
 		first, second = arg[0].split(".")
 		if side == "Server":
 			config[first][second] = eval(arg[1])
-			log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": first + "." + second, "value": eval(arg[1]), "operator": by})) # 协议 3.6.4
+			log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": first + "." + second, "value": eval(arg[1]), "operator": by})) # 协议 3.5.4
 			for i in range(len(users)):
 				if users[i]["status"] in ["Online", "Admin", "Root"]:
-					send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": first + "." + second, "value": eval(arg[1]), "operator": by}})) # 协议 3.6.2
+					send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": first + "." + second, "value": eval(arg[1]), "operator": by}})) # 协议 3.5.2
 		if side == "Client":
-			upload({"type": "MISC.CONFIG.POST", "key": first + "." + second, "value": eval(arg[1])}) # 协议 3.6.1
+			upload({"type": "SERVER.CONFIG.POST", "key": first + "." + second, "value": eval(arg[1])}) # 协议 3.5.1
 	except:
 		printc(verbose, "指令格式不正确，请重试。")
 		return
@@ -1392,28 +1385,28 @@ def do_ban(arg, verbose=True, by=-1):
 			if side == "Server":
 				ips = [item for item in ips if not item in config["ban"]["ip"]]
 				config["ban"]["ip"] += ips
-				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.5.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.5.2
 			if side == "Client":
 				ips = [item for item in ips if not item in config["ban"]["ip"]]
 				new_value = config["ban"]["ip"] + ips
-				upload({"type": "MISC.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.6.1
+				upload({"type": "SERVER.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.5.1
 			printc(verbose, "操作成功，共计封禁了 {} 个 IP 地址。".format(len(ips)))
 		
 		if arg[1] == "remove":
 			if side == "Server":
 				ips = [item for item in ips if item in config["ban"]["ip"]]
 				config["ban"]["ip"] = [item for item in config["ban"]["ip"] if not item in ips]
-				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.5.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.5.2
 			if side == "Client":
 				ips = [item for item in ips if item in config["ban"]["ip"]]
 				new_value = [item for item in config["ban"]["ip"] if not item in ips]
-				upload({"type": "MISC.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.6.1
+				upload({"type": "SERVER.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.5.1
 			printc(verbose, "操作成功，共计解除封禁了 {} 个 IP 地址。".format(len(ips)))
 	
 	if arg[0] == "words":
@@ -1435,14 +1428,14 @@ def do_ban(arg, verbose=True, by=-1):
 				return
 			if side == "Server":
 				config["ban"]["words"].append(arg[2])
-				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.5.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.5.2
 			if side == "Client":
 				new_value = config["ban"]["words"][:]
 				new_value.append(arg[2])
-				upload({"type": "MISC.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.6.1
+				upload({"type": "SERVER.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.5.1
 			printc(verbose, "操作成功。")
 		
 		if arg[1] == "remove":
@@ -1451,14 +1444,14 @@ def do_ban(arg, verbose=True, by=-1):
 				return
 			if side == "Server":
 				config["ban"]["words"].remove(arg[2])
-				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.5.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.5.2
 			if side == "Client":
 				new_value = config["ban"]["words"][:]
 				new_value.remove(arg[2])
-				upload({"type": "MISC.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.6.1
+				upload({"type": "SERVER.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.5.1
 			printc(verbose, "操作成功。")
 
 def do_broadcast(arg, message=None, verbose=True, by=-1):
@@ -1784,7 +1777,7 @@ def do_save(arg=None):
 		with open("./config.json", "w", encoding="utf-8") as f:
 			json.dump(config, f)
 		print("参数已经成功保存到配置文件 config.json，下次启动时将自动加载配置项。")
-		log_queue.put(json.dumps({"type": "MISC.CONFIG.SAVE", "time": time_str()})) # 协议 3.5
+		log_queue.put(json.dumps({"type": "SERVER.CONFIG.SAVE", "time": time_str()})) # 协议 3.5.3
 	except:
 		print("无法将参数保存到配置文件 config.json，请稍后重试。")
 
@@ -1802,14 +1795,12 @@ def do_exit(arg=None):
 	# 来清除 ANSI 文本序列带来的显示效果，
 	# 防止干扰用户后续的终端使用
 	print("\033[0m\033[1;36m再见！\033[0m")
+	log_queue.put(json.dumps({"type": "SERVER.STOP.LOG", "time": time_str()})) # 协议 3.4.2
 	if side == "Server":
-		log_queue.put(json.dumps({"type": "MISC.SERVER_STOP.LOG", "time": time_str()})) # 协议 3.2.2
 		for i in range(len(users)):
 			if users[i]["status"] in ["Pending", "Online", "Admin", "Root"]:
-				send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.SERVER_STOP.ANNOUNCE"}})) # 协议 3.2.1
+				send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.STOP.ANNOUNCE"}})) # 协议 3.4.1
 		server_socket.close()
-	if side == "Client":
-		log_queue.put(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()})) # 协议 3.4
 	exit_flag = True
 	my_socket.close()
 	return
@@ -1999,7 +1990,7 @@ def thread_gate():
 			users_abstract = []
 			for i in range(len(users)):
 				users_abstract.append({"username": users[i]["username"], "status": users[i]["status"]})
-			send_queue.put(json.dumps({"to": uid, "content": {"type": "MISC.DATA", "server_version": VERSION, "uid": uid, "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
+			send_queue.put(json.dumps({"to": uid, "content": {"type": "SERVER.DATA", "server_version": VERSION, "uid": uid, "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
 
 def thread_process():
 	global online_count
@@ -2035,7 +2026,7 @@ def thread_process():
 					do_doorman("reject " + str(content["uid"]), False, sender)
 				if content["status"] == "Online":
 					do_doorman("accept " + str(content["uid"]), False, sender)
-			if content["type"] == "MISC.CONFIG.POST": # 协议 3.6.1
+			if content["type"] == "SERVER.CONFIG.POST": # 协议 3.5.1
 				do_config("{} {}".format(content["key"], repr(content["value"])), False, sender)
 
 def thread_receive():
@@ -2090,7 +2081,7 @@ def thread_send():
 			# 先发送心跳数据（连续 10 个换行符）检查客户端是否下线
 			try:
 				for _ in range(10):
-					users[message["to"]]["body"].send(bytes("\n", encoding="utf-8"))
+					users[message["to"]]["body"].send(bytes("\n", encoding="utf-8"))# 协议 4
 			except:
 				users[message["to"]]["body"].close() # 关闭相应 TCP socket
 				users[message["to"]]["status"] = "Offline"
@@ -2163,7 +2154,7 @@ def thread_check():
 				try:
 					# 发送心跳数据（连续 10 个换行符）
 					for _ in range(10):
-						users[i]["body"].send(bytes("\n", encoding="utf-8"))
+						users[i]["body"].send(bytes("\n", encoding="utf-8")) # 协议 4
 				except:
 					users[i]["body"].close() # 关闭相应 TCP socket
 					users[i]["status"] = "Offline"
@@ -2201,7 +2192,7 @@ def thread_input():
 			print("\033[8;30m", end="", flush=True)
 			blocked = False
 			continue
-		log_queue.put(json.dumps({"type": "MISC.COMMAND", "time": time_str(), "command": command})) # 协议 3.3
+		log_queue.put(json.dumps({"type": "SERVER.COMMAND", "time": time_str(), "command": command})) # 协议 3.3
 		
 		# 将缩写形式替换为完整形式
 		for i in list(ABBREVIATION_TABLE.keys()):
@@ -2520,7 +2511,7 @@ def main():
 				sys.exit(1)
 			
 			with open("./log.ndjson", "a", encoding="utf-8") as file:
-				file.write(json.dumps({"type": "MISC.START", "time": time_str(), "stamp": stamp, "version": VERSION, "config": config}) + "\n") # 协议 3.1
+				file.write(json.dumps({"type": "SERVER.START", "time": time_str(), "stamp": stamp, "version": VERSION, "config": config}) + "\n") # 协议 3.1
 			
 			side = "Server"
 			prints("启动成功！", "green")
@@ -2640,7 +2631,7 @@ def main():
 				my_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30)
 			
 			with open("./log.ndjson", "a", encoding="utf-8") as file:
-				file.write(json.dumps({"type": "MISC.START", "time": time_str(), "stamp": stamp, "version": VERSION, "config": config}) + "\n") # 协议 3.1
+				file.write(json.dumps({"type": "SERVER.START", "time": time_str(), "stamp": stamp, "version": VERSION, "config": config}) + "\n") # 协议 3.1
 			
 			# 核验协议 1.2，获取加入请求结果
 			try:
@@ -2676,7 +2667,7 @@ def main():
 				if seconds_consumed == 11:
 					prints("（也有可能是对方服务器端口被防火墙拦截，请联系服务器所有者确认，或检查本地网络及防火墙设置。）", "red")
 				with open("./log.ndjson", "a", encoding="utf-8") as file:
-					file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+					file.write(json.dumps({"type": "SERVER.STOP.LOG", "time": time_str()}) + "\n") # 协议 3.4.2
 				input("\033[0m")
 				sys.exit(1)
 			
@@ -2684,7 +2675,7 @@ def main():
 				print()
 				prints("连接失败：{}".format(RESULTS[message["result"]]), "red")
 				with open("./log.ndjson", "a", encoding="utf-8") as file:
-					file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+					file.write(json.dumps({"type": "SERVER.STOP.LOG", "time": time_str()}) + "\n") # 协议 3.4.2
 				input("\033[0m")
 				sys.exit(1)
 			
@@ -2704,12 +2695,12 @@ def main():
 						message = get_message()
 						if not message:
 							raise
-						# 特殊情况：聊天室服务端已经关闭 (协议 3.5.1)
-						if message["type"] == "MISC.SERVER_STOP.ANNOUNCE":
+						# 特殊情况：聊天室服务端已经关闭 (协议 3.4.1)
+						if message["type"] == "SERVER.STOP.ANNOUNCE":
 							prints("聊天室服务端已经关闭。", "red")
 							prints("连接失败。", "red")
 							with open("./log.ndjson", "a", encoding="utf-8") as file:
-								file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+								file.write(json.dumps({"type": "SERVER.STOP.LOG", "time": time_str()}) + "\n") # 协议 3.4.2
 							input("\033[0m")
 							sys.exit(1)
 						# 一般情况：人工审核完成 (协议 1.3)
@@ -2718,7 +2709,7 @@ def main():
 							prints("服务端管理员 {} (UID = {}) 拒绝了您的连接请求。".format(message["operator"]["username"], message["operator"]["uid"]), "red")
 							prints("连接失败。", "red")
 							with open("./log.ndjson", "a", encoding="utf-8") as file:
-								file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+								file.write(json.dumps({"type": "SERVER.STOP.LOG", "time": time_str()}) + "\n") # 协议 3.4.2
 							input("\033[0m")
 							sys.exit(1)
 						if message["accepted"]:

--- a/LTS.py
+++ b/LTS.py
@@ -13,9 +13,9 @@
 """
 # TouchFish 协议文档
 
-本协议文档版本：v2.5.0
+本协议文档版本：v2.6.0
 
-本协议分为三个部分：`Gate`，`Chat`，`Server`。
+本协议分为三个部分：`Gate`，`Chat`，`Misc`。
 
 协议均使用 NDJSON（JSON 格式，相邻两个 JSON 以换行符分隔）格式进行发送。
 
@@ -23,6 +23,8 @@
 
 # 协议更新日志
 
+- Protocol v2.6.0 (TouchFish v4.9.0)
+  - 恢复 v2.3.0 的字段更改
 - Protocol v2.5.0 (TouchFish v4.8.0)
   - 撤销 v2.3.0 的字段更改
 - Protocol v2.4.0 (TouchFish v4.7.0)
@@ -215,29 +217,29 @@
 
 ---
 
-# 3 Server
+# 3 Misc
 
 这个部分是关于程序运行情况的协议内容。
 
 ## 3.1 Start
 
-`{ type: "SERVER.START", time: time, stamp: number, server_version: string, config: JSON }`
+`{ type: "MISC.START", time: time, stamp: number, version: string, config: JSON }`
 
 程序将启动时的启动参数写入日志。
 
-- `type`: `"SERVER.START"`
+- `type`: `"MISC.START"`
 - `time`: 同上。
 - `stamp`: 用于指定文件保存路径，取启动时的 UNIX 时间戳乘 `10 ** 6` 后向下取整。
-- `server_version`: 字符串，表示服务端程序版本。（下同）
+- `version`: 字符串，表示服务端程序版本。（下同）
 - `config`: JSON 对象，表示启动参数。（具体格式详见代码，下同）
 
 ## 3.2 Data
 
-`{ type: "SERVER.DATA", server_version: string, uid: number, config: JSON, users: [JSON, ...], chat_history: [JSON, ...] }`
+`{ type: "MISC.DATA", server_version: string, uid: number, config: JSON, users: [JSON, ...], chat_history: [JSON, ...] }`
 
 用于向新连接的客户端提供完整上下文。
 
-- `type`: `"SERVER.DATA"`
+- `type`: `"MISC.DATA"`
 - `server_version`: 同上。
 - `uid`: 表示服务端分配给该用户的用户 ID。
 - `config`: 同上。
@@ -253,83 +255,83 @@
 
 ## 3.3 Command
 
-`{ type: "SERVER.COMMAND", time: time, command: string }`
+`{ type: "MISC.COMMAND", time: time, command: string }`
 
 程序将用户输入的指令写入日志。
 
-- `type`: `"SERVER.COMMAND"`
+- `type`: `"MISC.COMMAND"`
 - `time`: 同上。
 - `command`: 输入的指令。
 
 ## 3.4 Client Stop
 
-`{ type: "SERVER.CLIENT_STOP", time: time }`
+`{ type: "MISC.CLIENT_STOP", time: time }`
 
 客户端正常关闭时将事件写入日志。
 
-- `type`: `"MISC.SERVER.CLIENT_STOP"`
+- `type`: `"MISC.MISC.CLIENT_STOP"`
 - `time`: 同上。
 
-## 3.5 Stop
+## 3.5 Server Stop
 
 服务端正常关闭时的协议。
 
 ### 3.5.1 Announce
 
-`{ type: "SERVER.STOP.ANNOUNCE" }`
+`{ type: "MISC.SERVER_STOP.ANNOUNCE" }`
 
 服务端正常关闭时，向全体客户端进行广播。
 
-- `type`: `"SERVER.STOP.ANNOUNCE"`
+- `type`: `"MISC.SERVER_STOP.ANNOUNCE"`
 
 ### 3.5.2 Log
 
-`{ type: "SERVER.STOP.LOG", time: time }`
+`{ type: "MISC.SERVER_STOP.LOG", time: time }`
 
 服务端正常关闭时将事件写入日志。
 
-- `type`: `"SERVER.STOP.LOG"`
+- `type`: `"MISC.SERVER_STOP.LOG"`
 - `time`: 同上。
 
 ## 3.6 Config
 
 ### 3.6.1 Post
 
-`{ type: "SERVER.CONFIG.POST", key: string, value: any }`
+`{ type: "MISC.CONFIG.POST", key: string, value: any }`
 
 管理员向服务端发送配置修改请求。
 
-- `type`: `"SERVER.CONFIG.POST"`
+- `type`: `"MISC.CONFIG.POST"`
 - `key`: 配置项名称。（下同）
 - `value`: 配置值。（下同）
 
 ### 3.6.2 Change
 
-`{ type: "SERVER.CONFIG.CHANGE", key: string, value: any, operator: number }`
+`{ type: "MISC.CONFIG.CHANGE", key: string, value: any, operator: number }`
 
 服务端向客户端广播配置修改事件。
 
-- `type`: `"SERVER.CONFIG.CHANGE"`
+- `type`: `"MISC.CONFIG.CHANGE"`
 - `key`: 同上。
 - `value`: 同上。
 - `operator`: 执行修改操作的用户 ID。
 
 ### 3.6.3 Save
 
-`{ type: "SERVER.CONFIG.SAVE", time: time }`
+`{ type: "MISC.CONFIG.SAVE", time: time }`
 
 服务端将聊天室房主导出配置的事件写入日志。
 
-- `type`: `"SERVER.CONFIG.SAVE"`
+- `type`: `"MISC.CONFIG.SAVE"`
 - `time`: 同上。
 
 ### 3.6.4 Log
 
-`{ type: "SERVER.CONFIG.LOG", time: time, key: string, value: any, operator: number }`
+`{ type: "MISC.CONFIG.LOG", time: time, key: string, value: any, operator: number }`
 
 服务端将配置修改事件写入日志。
 
-- `type`: `"SERVER.CONFIG.LOG"`
+- `type`: `"MISC.CONFIG.LOG"`
 - `time`: 同上。
 - `key`: 同上。
 - `value`: 同上。
@@ -360,7 +362,7 @@ import threading
 import time
 
 # 程序版本
-VERSION = "v4.8.0"
+VERSION = "v4.9.0"
 
 # 用于客户端解析协议 1.2
 RESULTS = \
@@ -982,7 +984,7 @@ def process(message):
 			prints("\033[0m\033[1;36m再见！\033[0m")
 			exit_flag = True
 			return
-	if message["type"] == "SERVER.CONFIG.CHANGE": # 服务端参数变更 (协议 3.6.2)
+	if message["type"] == "MISC.CONFIG.CHANGE": # 服务端参数变更 (协议 3.6.2)
 		announce(message["operator"])
 		prints("配置项 {} 变更为：".format(message["key"]) + str(message["value"]), "cyan")
 		if side == "Client": # 同上
@@ -993,7 +995,7 @@ def process(message):
 				prints("该配置项相比修改前移除了：{}".format(str(deletions)), "cyan")
 		config[message["key"].split(".")[0]][message["key"].split(".")[1]] = message["value"]
 		return
-	if message["type"] == "SERVER.STOP.ANNOUNCE": # 服务端关闭 (协议 3.5.1)
+	if message["type"] == "MISC.SERVER_STOP.ANNOUNCE": # 服务端关闭 (协议 3.5.1)
 		if side == "Client": # 同上
 			announce(0)
 			prints("聊天室服务端已经关闭。", "cyan")
@@ -1132,7 +1134,7 @@ def do_doorman(arg, verbose=True, by=-1):
 			for i in range(len(users)):
 				users_abstract.append({"username": users[i]["username"], "status": users[i]["status"]})
 			send_queue.put(json.dumps({"to": arg[1], "content": {"type": "GATE.REVIEW_RESULT", "accepted": True, "operator": {"username": users[by]["username"], "uid": by}}})) # 协议 1.3
-			send_queue.put(json.dumps({"to": arg[1], "content": {"type": "SERVER.DATA", "server_version": VERSION, "uid": arg[1], "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
+			send_queue.put(json.dumps({"to": arg[1], "content": {"type": "MISC.DATA", "server_version": VERSION, "uid": arg[1], "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
 		if side == "Client":
 			upload({"type": "GATE.STATUS_CHANGE.REQUEST", "status": "Online", "uid": arg[1]}) # 协议 1.6.1
 	
@@ -1313,12 +1315,12 @@ def do_config(arg, verbose=True, by=-1):
 		first, second = arg[0].split(".")
 		if side == "Server":
 			config[first][second] = eval(arg[1])
-			log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": first + "." + second, "value": eval(arg[1]), "operator": by})) # 协议 3.6.4
+			log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": first + "." + second, "value": eval(arg[1]), "operator": by})) # 协议 3.6.4
 			for i in range(len(users)):
 				if users[i]["status"] in ["Online", "Admin", "Root"]:
-					send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": first + "." + second, "value": eval(arg[1]), "operator": by}})) # 协议 3.6.2
+					send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": first + "." + second, "value": eval(arg[1]), "operator": by}})) # 协议 3.6.2
 		if side == "Client":
-			upload({"type": "SERVER.CONFIG.POST", "key": first + "." + second, "value": eval(arg[1])}) # 协议 3.6.1
+			upload({"type": "MISC.CONFIG.POST", "key": first + "." + second, "value": eval(arg[1])}) # 协议 3.6.1
 	except:
 		printc(verbose, "指令格式不正确，请重试。")
 		return
@@ -1359,28 +1361,28 @@ def do_ban(arg, verbose=True, by=-1):
 			if side == "Server":
 				ips = [item for item in ips if item not in config["ban"]["ip"]]
 				config["ban"]["ip"] += ips
-				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.6.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.6.2
 			if side == "Client":
 				ips = [item for item in ips if item not in config["ban"]["ip"]]
 				new_value = config["ban"]["ip"] + ips
-				upload({"type": "SERVER.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.6.1
+				upload({"type": "MISC.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.6.1
 			printc(verbose, "操作成功，共计封禁了 {} 个 IP 地址。".format(len(ips)))
 		
 		if arg[1] == "remove":
 			if side == "Server":
 				ips = [item for item in ips if item in config["ban"]["ip"]]
 				config["ban"]["ip"] = [item for item in config["ban"]["ip"] if not item in ips]
-				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.ip", "value": config["ban"]["ip"], "operator": by})) # 协议 3.6.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.ip", "value": config["ban"]["ip"], "operator": by}})) # 协议 3.6.2
 			if side == "Client":
 				ips = [item for item in ips if item in config["ban"]["ip"]]
 				new_value = [item for item in config["ban"]["ip"] if not item in ips]
-				upload({"type": "SERVER.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.6.1
+				upload({"type": "MISC.CONFIG.POST", "key": "ban.ip", "value": new_value}) # 协议 3.6.1
 			printc(verbose, "操作成功，共计解除封禁了 {} 个 IP 地址。".format(len(ips)))
 	
 	if arg[0] == "words":
@@ -1402,14 +1404,14 @@ def do_ban(arg, verbose=True, by=-1):
 				return
 			if side == "Server":
 				config["ban"]["words"].append(arg[2])
-				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.6.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.6.2
 			if side == "Client":
 				new_value = config["ban"]["words"][:]
 				new_value.append(arg[2])
-				upload({"type": "SERVER.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.6.1
+				upload({"type": "MISC.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.6.1
 			printc(verbose, "操作成功。")
 		
 		if arg[1] == "remove":
@@ -1418,14 +1420,14 @@ def do_ban(arg, verbose=True, by=-1):
 				return
 			if side == "Server":
 				config["ban"]["words"].remove(arg[2])
-				log_queue.put(json.dumps({"type": "SERVER.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.6.4
+				log_queue.put(json.dumps({"type": "MISC.CONFIG.LOG", "time": time_str(), "key": "ban.words", "value": config["ban"]["words"], "operator": by})) # 协议 3.6.4
 				for i in range(len(users)):
 					if users[i]["status"] in ["Online", "Admin", "Root"]:
-						send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.6.2
+						send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.CONFIG.CHANGE", "key": "ban.words", "value": config["ban"]["words"], "operator": by}})) # 协议 3.6.2
 			if side == "Client":
 				new_value = config["ban"]["words"][:]
 				new_value.remove(arg[2])
-				upload({"type": "SERVER.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.6.1
+				upload({"type": "MISC.CONFIG.POST", "key": "ban.words", "value": new_value}) # 协议 3.6.1
 			printc(verbose, "操作成功。")
 
 def do_broadcast(arg, message=None, verbose=True, by=-1):
@@ -1751,7 +1753,7 @@ def do_save(arg=None):
 		with open("./config.json", "w", encoding="utf-8") as f:
 			json.dump(config, f)
 		print("参数已经成功保存到配置文件 config.json，下次启动时将自动加载配置项。")
-		log_queue.put(json.dumps({"type": "SERVER.CONFIG.SAVE", "time": time_str()})) # 协议 3.5
+		log_queue.put(json.dumps({"type": "MISC.CONFIG.SAVE", "time": time_str()})) # 协议 3.5
 	except:
 		print("无法将参数保存到配置文件 config.json，请稍后重试。")
 
@@ -1770,13 +1772,13 @@ def do_exit(arg=None):
 	# 防止干扰用户后续的终端使用
 	print("\033[0m\033[1;36m再见！\033[0m")
 	if side == "Server":
-		log_queue.put(json.dumps({"type": "SERVER.STOP.LOG", "time": time_str()})) # 协议 3.2.2
+		log_queue.put(json.dumps({"type": "MISC.SERVER_STOP.LOG", "time": time_str()})) # 协议 3.2.2
 		for i in range(len(users)):
 			if users[i]["status"] in ["Pending", "Online", "Admin", "Root"]:
-				send_queue.put(json.dumps({"to": i, "content": {"type": "SERVER.STOP.ANNOUNCE"}})) # 协议 3.2.1
+				send_queue.put(json.dumps({"to": i, "content": {"type": "MISC.SERVER_STOP.ANNOUNCE"}})) # 协议 3.2.1
 		server_socket.close()
 	if side == "Client":
-		log_queue.put(json.dumps({"type": "SERVER.CLIENT_STOP", "time": time_str()})) # 协议 3.4
+		log_queue.put(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()})) # 协议 3.4
 	exit_flag = True
 	my_socket.close()
 	return
@@ -1966,7 +1968,7 @@ def thread_gate():
 			users_abstract = []
 			for i in range(len(users)):
 				users_abstract.append({"username": users[i]["username"], "status": users[i]["status"]})
-			send_queue.put(json.dumps({"to": uid, "content": {"type": "SERVER.DATA", "server_version": VERSION, "uid": uid, "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
+			send_queue.put(json.dumps({"to": uid, "content": {"type": "MISC.DATA", "server_version": VERSION, "uid": uid, "config": config, "users": users_abstract, "chat_history": history}})) # 协议 3.2
 
 def thread_process():
 	global online_count
@@ -2002,7 +2004,7 @@ def thread_process():
 					do_doorman("reject " + str(content["uid"]), False, sender)
 				if content["status"] == "Online":
 					do_doorman("accept " + str(content["uid"]), False, sender)
-			if content["type"] == "SERVER.CONFIG.POST": # 协议 3.6.1
+			if content["type"] == "MISC.CONFIG.POST": # 协议 3.6.1
 				do_config("{} {}".format(content["key"], repr(content["value"])), False, sender)
 
 def thread_receive():
@@ -2165,7 +2167,7 @@ def thread_input():
 			print("\033[8;30m", end="", flush=True)
 			blocked = False
 			continue
-		log_queue.put(json.dumps({"type": "SERVER.COMMAND", "time": time_str(), "command": command})) # 协议 3.3
+		log_queue.put(json.dumps({"type": "MISC.COMMAND", "time": time_str(), "command": command})) # 协议 3.3
 		
 		# 将缩写形式替换为完整形式
 		for i in list(ABBREVIATION_TABLE.keys()):
@@ -2477,7 +2479,7 @@ def main():
 				sys.exit(1)
 			
 			with open("./log.ndjson", "a", encoding="utf-8") as file:
-				file.write(json.dumps({"type": "SERVER.START", "time": time_str(), "stamp": stamp, "server_version": VERSION, "config": config}) + "\n") # 协议 3.1
+				file.write(json.dumps({"type": "MISC.START", "time": time_str(), "stamp": stamp, "version": VERSION, "config": config}) + "\n") # 协议 3.1
 			
 			side = "Server"
 			prints("启动成功！", "green")
@@ -2597,7 +2599,7 @@ def main():
 				my_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30)
 			
 			with open("./log.ndjson", "a", encoding="utf-8") as file:
-				file.write(json.dumps({"type": "SERVER.START", "time": time_str(), "stamp": stamp, "server_version": VERSION, "config": config}) + "\n") # 协议 3.1
+				file.write(json.dumps({"type": "MISC.START", "time": time_str(), "stamp": stamp, "version": VERSION, "config": config}) + "\n") # 协议 3.1
 			
 			# 核验协议 1.2，获取加入请求结果
 			try:
@@ -2633,7 +2635,7 @@ def main():
 				if seconds_consumed == 11:
 					prints("（也有可能是对方服务器端口被防火墙拦截，请联系服务器所有者确认，或检查本地网络及防火墙设置。）", "red")
 				with open("./log.ndjson", "a", encoding="utf-8") as file:
-					file.write(json.dumps({"type": "SERVER.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+					file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
 				input("\033[0m")
 				sys.exit(1)
 			
@@ -2641,7 +2643,7 @@ def main():
 				print()
 				prints("连接失败：{}".format(RESULTS[message["result"]]), "red")
 				with open("./log.ndjson", "a", encoding="utf-8") as file:
-					file.write(json.dumps({"type": "SERVER.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+					file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
 				input("\033[0m")
 				sys.exit(1)
 			
@@ -2662,11 +2664,11 @@ def main():
 						if not message:
 							raise
 						# 特殊情况：聊天室服务端已经关闭 (协议 3.5.1)
-						if message["type"] == "SERVER.STOP.ANNOUNCE":
+						if message["type"] == "MISC.SERVER_STOP.ANNOUNCE":
 							prints("聊天室服务端已经关闭。", "red")
 							prints("连接失败。", "red")
 							with open("./log.ndjson", "a", encoding="utf-8") as file:
-								file.write(json.dumps({"type": "SERVER.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+								file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
 							input("\033[0m")
 							sys.exit(1)
 						# 一般情况：人工审核完成 (协议 1.3)
@@ -2675,7 +2677,7 @@ def main():
 							prints("服务端管理员 {} (UID = {}) 拒绝了您的连接请求。".format(message["operator"]["username"], message["operator"]["uid"]), "red")
 							prints("连接失败。", "red")
 							with open("./log.ndjson", "a", encoding="utf-8") as file:
-								file.write(json.dumps({"type": "SERVER.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
+								file.write(json.dumps({"type": "MISC.CLIENT_STOP", "time": time_str()}) + "\n") # 协议 3.4
 							input("\033[0m")
 							sys.exit(1)
 						if message["accepted"]:

--- a/LTS.py
+++ b/LTS.py
@@ -15,7 +15,7 @@
 
 本协议文档版本：v2.8.0
 
-本协议分为三个部分：`Gate`，`Chat`，`Misc`。
+本协议分为三个部分：`Gate`，`Chat`，`Server`。
 
 协议均使用 NDJSON（JSON 格式，相邻两个 JSON 以换行符分隔）格式进行发送。
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: TouchFish Community <johnchiao@outlook.com>
 pkgname=touchfish
-pkgver=4.9.0
+pkgver=4.11.0
 pkgrel=1
 pkgdesc="FOSS multi-distribution LAN chatting tool"
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: TouchFish Community <johnchiao@outlook.com>
 pkgname=touchfish
-pkgver=4.7.0
+pkgver=4.9.0
 pkgrel=1
 pkgdesc="FOSS multi-distribution LAN chatting tool"
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!WARNING]
 > **这是 TouchFish v4 版本，自 v4 开始不再向前兼容 v1 - v3。**
 >
-> **根据规划，此版本（v4.9.0）是 TouchFish v4 的最后一个子版本。TouchFish v5 正在施工，[链接](https://github.com/2044-space-elevator/TFV5_server)。下一版本预计将进入 v5。**
+> **根据规划，此版本（v4.11.0）是 TouchFish v4 的最后一个子版本。TouchFish v5 正在施工，[链接](https://github.com/2044-space-elevator/TFV5_server)。下一版本预计将进入 v5。**
 
 > [!IMPORTANT]
 > **重要通知：贡献者须知**
@@ -134,7 +134,7 @@ TouchFish 拥有丰富的衍生版本生态系统，满足不同用户需求：
 | 版本名称 | 简称 | 主要作者 | 链接 | 对 v1-3 支持 | 语言 | 平台支持 | 特色 | 对 v4 支持
 |---------|------|----------|----|-----|------|----------|------|--|
 | LTS | TF | @2044-space-elevator, @035966-L3 和其他 LTS 贡献者 | [github](#发行版本生态), [mirror](https://mirror.ilovescratch.us.ci/TouchFish/LTS/) | ✅ | Python | Win, macOS, Linux | 根版本，长期支持 | ✅ |
-| Astra | TFA | @ILoveScratch2 | [github](https://github.com/ILoveScratch2/TouchFish-Astra), [mirror](https://mirror.ilovescratch.us.ci/TouchFish/Astra/) | ✅ | Dart | 全平台 (UI) | 最佳发行版之一，现代化 UI | ✅^ |
+| Astra | TFA | @ILoveScratch2 | [github](https://github.com/ILoveScratch2/TouchFish-Astra), [mirror](https://mirror.ilovescratch.us.ci/TouchFish/Astra/) | ✅ | Dart | 全平台 (UI) | 最佳发行版之一，现代化 UI | ✅ |
 | UI Remake | TFUR | @pztsdy | [github](https://github.com/pztsdy/touchfish_ui_remake), [main-mirror](https://mirror.ilovescratch.us.ci/TouchFish/UI%20Remake/), [update-branch](https://github.com/pztsdy/touchfish_ui_remake/tree/update) | ✅ | Node.JS | Win, macOS*, Linux* | 现代化 UI，Markdown，代码高亮（生命周期已终止~~即停更~~） | ❌ |
 | Plus | Plus | @ayf2192538031 | [github](https://github.com/2044-space-elevator/TouchFishPlus), [mirror](https://mirror.ilovescratch.us.ci/TouchFish/Plus%20(%E6%BA%90%E4%BB%A3%E7%A0%81)/) | ❌ | Python | Win*, macOS*, Linux* | 增强功能集 | ❌ |
 | Pro | Pro | @BoXueDuoCai | [github](https://github.com/PigeonTechGroup/TouchFishPro), [mirror](https://mirror.ilovescratch.us.ci/TouchFish/Pro%20(%E6%BA%90%E4%BB%A3%E7%A0%81)/) | ✅ | Python | Win*, macOS*, Linux* | Markdown，LaTeX，用户高亮 | ❌ |
@@ -142,8 +142,6 @@ TouchFish 拥有丰富的衍生版本生态系统，满足不同用户需求：
 | More | More | @xie2870 | [github](https://github.com/xie2870/touchfish_more), [gitee](https://gitee.com/xx2870/touchfish_more), [mirror](https://mirror.ilovescratch.us.ci/TouchFish/More(Lite)/) | ✅ | Python | Win*, macOS*, Linux (UI) | 性能优化，镜像站 | ❌ |
 
 > 标 * 的版本可能需要自行编译、直接运行代码或缺少预编译包。
->
-> 标 ^ 的版本可能与 LTS v4.9.0 存在少量兼容性问题，此时建议使用 LTS v4.8.0。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!WARNING]
 > **这是 TouchFish v4 版本，自 v4 开始不再向前兼容 v1 - v3。**
 >
-> **根据规划，此版本（v4.7.0）是 TouchFish v4 的最后一个子版本。TouchFish v5 正在施工，[链接](https://github.com/2044-space-elevator/TFV5_server)。下一版本预计将进入 v5。**
+> **根据规划，此版本（v4.9.0）是 TouchFish v4 的最后一个子版本。TouchFish v5 正在施工，[链接](https://github.com/2044-space-elevator/TFV5_server)。下一版本预计将进入 v5。**
 
 > [!IMPORTANT]
 > **重要通知：贡献者须知**
@@ -45,7 +45,7 @@
 > 不建议下载预编译的二进制文件，建议通过源代码部署
 > `wget https://github.com/2044-space-elevator/TouchFish/releases/download/v4.7.0/LTS.py && python3 LTS.py`
 > 
-> （也可以通过 @ILoveScratch2 提供的镜像站，但是截至 2026/2/23 只更新到了 v4.6 版本：`wget https://mirror.ilovescratch.us.ci/api/net/379814722/LTS.py && python3 LTS.py`）
+> （也可以通过 @ILoveScratch2 提供的镜像站，但是截至 2026/7/13 只更新到了 v4.7.0 版本：`wget https://mirror.ilovescratch.us.ci/api/net/183301217/LTS.py && python3 LTS.py`）
 
 1. **获取内网 IP 地址**：
    - **Windows**: 命令提示符执行 `ipconfig`，查找 "无线局域网适配器 WLAN" 下的 "IPv4 地址"
@@ -129,7 +129,7 @@
 
 TouchFish 拥有丰富的衍生版本生态系统，满足不同用户需求：
 
-**这里的大部分发行版都暂不支持 v4 版本，如需使用请前往 [Release](https://github.com/2044-space-elevator/TouchFish/releases) 页面下载旧版本（v3及以前）**
+**这里的大部分发行版都暂不支持 v4 版本，如需使用请前往 [Release](https://github.com/2044-space-elevator/TouchFish/releases) 页面下载旧版本（v3 及以前）**
 
 | 版本名称 | 简称 | 主要作者 | 链接 | 对 v1-3 支持 | 语言 | 平台支持 | 特色 | 对 v4 支持
 |---------|------|----------|----|-----|------|----------|------|--|
@@ -143,7 +143,7 @@ TouchFish 拥有丰富的衍生版本生态系统，满足不同用户需求：
 
 > 标 * 的版本可能需要自行编译、直接运行代码或缺少预编译包。
 >
-> 标 ^ 的版本可能与 LTS v4.6.0/v4.7.0 存在少量兼容性问题，此时建议使用 LTS v4.3.3。
+> 标 ^ 的版本可能与 LTS v4.9.0 存在少量兼容性问题，此时建议使用 LTS v4.8.0。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 > （这里的命令只针对 Linux 用户）
 > 
 > 不建议下载预编译的二进制文件，建议通过源代码部署
-> `wget https://github.com/2044-space-elevator/TouchFish/releases/download/v4.7.0/LTS.py && python3 LTS.py`
+> `wget https://github.com/2044-space-elevator/TouchFish/releases/download/v4.9.0/LTS.py && python3 LTS.py`
 > 
 > （也可以通过 @ILoveScratch2 提供的镜像站，但是截至 2026/7/13 只更新到了 v4.7.0 版本：`wget https://mirror.ilovescratch.us.ci/api/net/183301217/LTS.py && python3 LTS.py`）
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@
 >
 > （这里的命令只针对 Linux 用户）
 > 
-> 不建议下载预编译的二进制文件，建议通过源代码部署
-> `wget https://github.com/2044-space-elevator/TouchFish/releases/download/v4.9.0/LTS.py && python3 LTS.py`
+> 不建议下载预编译的二进制文件，建议通过源代码部署：
 > 
-> （也可以通过 @ILoveScratch2 提供的镜像站，但是截至 2026/7/13 只更新到了 v4.7.0 版本：`wget https://mirror.ilovescratch.us.ci/api/net/183301217/LTS.py && python3 LTS.py`）
+> `wget https://github.com/2044-space-elevator/TouchFish/releases/download/v4.11.0/LTS.py && python3 LTS.py`
+> 
+> （也可以通过 @ILoveScratch2 提供的镜像站，但是截至 2026/7/13 只更新到了 v4.7.0 版本：
+>
+> `wget https://mirror.ilovescratch.us.ci/api/net/183301217/LTS.py && python3 LTS.py`）
 
 1. **获取内网 IP 地址**：
    - **Windows**: 命令提示符执行 `ipconfig`，查找 "无线局域网适配器 WLAN" 下的 "IPv4 地址"


### PR DESCRIPTION
**本版本为安全更新。**

1. 修复 `doorman` 命令中没有提前检测客户端是否下线的问题
2. 修复客户端等待服务端批准加入失败时 `sys.exit(1)` 被错误捕获（应当不捕获）的问题
3. 修复客户端等待服务端批准加入的计时中 `time.sleep` 传入负数导致错误的问题
4. 将服务端默认配置中的 IP 由 `127.0.0.1` 改为 `0.0.0.0`
5. 将心跳数据由 1 个换行符改为 10 个换行符
6. 对广播消息将响铃 1 次改为响铃 5 次，间隔 1.5 秒
7. 添加协议中对心跳数据的说明（不改变协议）
8. 代码和文档整理
